### PR TITLE
fix pandas dependency bug

### DIFF
--- a/section-05-production-model-package/requirements/requirements.txt
+++ b/section-05-production-model-package/requirements/requirements.txt
@@ -2,7 +2,7 @@
 # to specify acceptable version ranges of our project dependencies. This gives us the flexibility to keep up with small
 # updates/fixes, whilst ensuring we don't install a major update which could introduce backwards incompatible changes.
 numpy>=1.20.0,<1.21.0
-pandas>=1.2.0,<1.3.0
+pandas>=1.3.5,<1.4.0
 pydantic>=1.8.1,<1.9.0
 scikit-learn>=0.24.0,<0.25.0
 strictyaml>=1.3.2,<1.4.0

--- a/section-06-model-serving-api/house-prices-api/requirements.txt
+++ b/section-06-model-serving-api/house-prices-api/requirements.txt
@@ -5,4 +5,4 @@ pydantic>=1.8.1,<1.9.0
 typing_extensions>=3.7.4,<3.8.0
 loguru>=0.5.3,<0.6.0
 # We will explain this in the course
-tid-regression-model==3.0.1
+tid-regression-model==3.0.3

--- a/section-07-ci-and-publishing/model-package/requirements/requirements.txt
+++ b/section-07-ci-and-publishing/model-package/requirements/requirements.txt
@@ -2,7 +2,7 @@
 # to specify acceptable version ranges of our project dependencies. This gives us the flexibility to keep up with small
 # updates/fixes, whilst ensuring we don't install a major update which could introduce backwards incompatible changes.
 numpy>=1.20.0,<1.21.0
-pandas>=1.2.0,<1.3.0
+pandas>=1.3.5,<1.4.0
 pydantic>=1.8.1,<1.9.0
 scikit-learn>=0.24.0,<0.25.0
 strictyaml>=1.3.2,<1.4.0


### PR DESCRIPTION
Students are seeing: `DeprecationWarning: distutils Version classes are deprecated` when running the tests with tox.

This is an obscure error, which is in numpy, but fixed in newer versions of pandas. You can see it referenced over in scipy here; https://github.com/scipy/scipy/issues/15254

I've bumped the pandas version to resolve, and also published an updated version of the package to pypi

@solegalli FYI