### PR TITLE
fix railway token variable def

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Deploy to Railway App (You must set RAILWAY_TOKEN env var)
           command: |
-            cd section-07-ci-and-publishing/house-prices-api && railway up --detach
+            cd section-07-ci-and-publishing/house-prices-api && RAILWAY_TOKEN=$RAILWAY_TOKEN railway up --detach
 
   section_07_test_and_upload_regression_model:
     <<: *defaults


### PR DESCRIPTION
I was getting a "Project Token not found" error with `section_07_deploy_app_to_railway` from CI/CD in CircleCI, using the code as is in the master branch of the repo ([trainindata/deploy-machine-learning-models](https://github.com/trainindata/deploying-machine-learning-models)), even though I had correctly set up the `RAILWAY_TOKEN` environmental variable. Investigating the [Railway's CLI documentation](https://docs.railway.app/develop/cli), I found that one should create a local variable from the environmental one, such that `RAILWAY_TOKEN=$RAILWAY_TOKEN` before calling the railway commands, as in the figure below:

![image](https://github.com/trainindata/deploying-machine-learning-models/assets/56833890/f150a6c4-d9c6-47ac-9988-0dc0889201ba)

I added that small piece of code to `.circleci/config.yml` and it fixed my issues. Please consider this PR if you think it is relevant.